### PR TITLE
Add simple systemd unit file

### DIFF
--- a/avahi_aliases/etc/systemd/system/avahi-aliases.service
+++ b/avahi_aliases/etc/systemd/system/avahi-aliases.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=avahi subdomain announcer
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/avahi-alias start
+ExecStop=/usr/local/bin/avahi-alias stop
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         ('/etc/init/',              ['avahi_aliases/etc/init/avahi-aliases.conf'] ),
         ('/etc/avahi/',             ['avahi_aliases/etc/avahi/aliases']),
         ('/etc/avahi/aliases.d/',   ['avahi_aliases/etc/avahi/aliases.d/default']),
+        ('/etc/systemd/system/',    ['avahi_aliases/etc/systemd/system/avahi-aliases.service'] ),
     ],
     zip_safe = False,
 )


### PR DESCRIPTION
Note: `/etc/systemd/system/` is the local machine's path, instead of the package-manager one under `/lib/systemd/system/`. I am unaware if there is some way to get pip install to put unit files in an equiv of `/usr/local/etc/systemd/system/` if the current OS supports that method. If so, that should be used instead, but this works too and is normal for others.

Other note: can pip install know which to install? upstart vs systemd?